### PR TITLE
Remove deprecated Fixnum message

### DIFF
--- a/lib/pbxplorer.rb
+++ b/lib/pbxplorer.rb
@@ -4,7 +4,9 @@ class String
   alias to_pbx_plist to_json
 end
 
-class Fixnum
+# Fixnum is deprecated in Ruby 2.4.0 and above, and it is recommended to use Integer class instead.
+klass_name = (Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0') ? 'Fixnum' : 'Integer')
+Module.const_get(klass_name).class_eval do
   alias to_pbx_plist to_json
 end
 


### PR DESCRIPTION
With Ruby 2.4.0, loading `pbxplorer` invokes the message:
```
pbxplorer.rb:7: warning: constant ::Fixnum is deprecated
```
I admit this small fix is a bit hacky – it checks for current `RUBY_VERSION`, and overrides `Integer` only if Ruby has version ≥`2.4.0`. Tests are all green.

Let me know what you think!