### PR TITLE
Remove quotes for CURRENT_PROJECT_VERSION value

### DIFF
--- a/lib/pbxplorer.rb
+++ b/lib/pbxplorer.rb
@@ -211,7 +211,7 @@ class XCProjectFile
 
   def save path=nil
     path ||= @path
-    File.open(path, "w") { |f| f.write @json.to_pbx_plist }
+    File.open(path, "w") { |f| f.write @json.to_pbx_plist.gsub( /\"CURRENT_PROJECT_VERSION\" = \"(\d+)\"/, "CURRENT_PROJECT_VERSION = \\1") }
   end
 
   def project


### PR DESCRIPTION
I am using this Gem along with Fastlane. In one of the steps within my production lanes, I use fastlane's `bump_build_number`. Before bumping the version number, I used `pbxplorer` to override code signing settings – however, somehow I get this error when bumping the build number:
```
Apple Generic Versioning is not enabled in this project.
Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html
```

After a lot of time digging around, fastlane 2.39.1 and above uses `agvtool` (i.e. Apple Generic Versioning Tool) to bump the build number. This led me to think that there's something fishy with `agvtool` after pbxproj rewrite, so I tried manually checking via `agvtool what-version`, and it fails.

Internally, `agvtool` looks for `CURRENT_PROJECT_VERSION` – but after the rewrite, it becomes `"CURRENT_PROJECT_VERSION"`. The added double-quotes are what's causing the `agvtool` to fail. This PR fixes that by contextually checking and removing quotes from `CURRENT_PROJECT_VERSION`.

I have been using this workaround for a few months now, without issues. Tests are all passing. Let me know what you think.